### PR TITLE
Define WoD simplied language

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.{txt}]
+indent_style = tab
+indent_size = 2
+
 [*.{md,yml,yaml}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 
 [*.{txt}]
 indent_style = tab
-indent_size = 2
+indent_size = 4
 
 [*.{md,yml,yaml}]
 indent_style = space

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Verify workout files
+on:
+  push:
+    branches-ignore:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: master
+          list-files: shell
+          filters: |
+            workout:
+              - added|modified: 'data/**'
+      - name: Markdown lint
+        if: steps.filter.outputs.workout == 'true'
+        uses: docker://avtodev/markdown-lint:v1
+        with:
+          config: .markdownlint.yaml
+          args: "${{ steps.filter.outputs.workout_files }}"
+      - name: Setup Go build environment
+        uses: actions/setup-go@v2
+        if: steps.filter.outputs.workout == 'true'
+        with:
+          go-version: '1.16'
+      - name: Parse workout files
+        if: steps.filter.outputs.workout == 'true'
+        run: |
+          cd pkg
+          for f in ${{ steps.filter.outputs.workout_files }}; do
+            go run main.go < "../$f"
+          done

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+default: true,
+no-hard-tabs: false
+MD041: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ No more bookmarks on your social media apps ;)
 ## The wishilist - v0 Roadmap
 
 - [x] Write down the WAC idea (more or less)
-- [ ] Dump initial workouts as yaml files. **Human oriented** and machine readable
+- [ ] Dump initial workouts as plain files. **Human oriented** and machine readable
 - [ ] Define WAC v0 YAML file schema. *One way all the way*
 - [ ] Prototype tool to export workouts for any WOD app. Target "Seconds" mobile app
 - [ ] ???

--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 
 > Are you a tired developer with a bunch of workouts in many places? Get WAC!
 
-Workout as code (WAC) is a structured way of storing workouts in plain text.
+Workout as code (WAC) is a simple but structured way of storing workouts.
 No more bookmarks on your social media apps ;)
 
 ## The wishilist - v0 Roadmap
 
-- [x] Write down the WAC idea (more or less)
-- [ ] Dump initial workouts as plain files. **Human oriented** and machine readable
-- [ ] Define WAC v0 YAML file schema. *One way all the way*
-- [ ] Prototype tool to export workouts for any WOD app. Target "Seconds" mobile app
+- [x] Write down the idea (more or less)
+- [x] Dump initial workouts as plain files. **Human oriented** and machine readable
+- [ ] Prototype wac tool- Lint workout files
+- [ ] Prototype wac tool - Export workouts as "Seconds" mobile app input file
+- [ ] *Maybe* separate the tool src code from workouts data
 - [ ] ???
 - [ ] Profit!
-
-PS: Do not add copyrighted workouts please!

--- a/README.md
+++ b/README.md
@@ -5,11 +5,16 @@
 Workout as code (WAC) is a simple but structured way of storing workouts.
 No more bookmarks on your social media apps ;)
 
+## Shush and give me some workouts
+
+The workouts are under `data/` directory, feel free to PR new ones.
+
+The wac cli is under incubation, but the wac files are a human readable so go nuts!
 ## The wishilist - v0 Roadmap
 
 - [x] Write down the idea (more or less)
 - [x] Dump initial workouts as plain files. **Human oriented** and machine readable
-- [ ] Prototype wac tool- Lint workout files
+- [x] Prototype wac tool- Lint workout files
 - [ ] Prototype wac tool - Export workouts as "Seconds" mobile app input file
 - [ ] *Maybe* separate the tool src code from workouts data
 - [ ] ???

--- a/data/funtional-20200316.md
+++ b/data/funtional-20200316.md
@@ -1,0 +1,30 @@
+## Warmup - 12min For time
+
+12  Burpees
+12  Lunges
+3min  Run
+
+9  Burpees
+9  Lunges
+3min  Run
+
+6  Burpees
+6  Lunges
+3min  Run
+
+## Then - For time
+
+50  explosive squats
+15  pushups
+
+## The Wod - 3x
+
+25  sit ups
+15  goblet squat
+50  explosive squats
+15  push ups
+
+## Finisher - 4x no rest
+
+2min  fast pace run
+1min  max reps splipt jumpbs

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,8 @@
+module github.com/jossemargt/workout-as-code
+
+go 1.16
+
+require (
+	github.com/alecthomas/participle/v2 v2.0.0-alpha6
+	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1
+)

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1,0 +1,15 @@
+github.com/alecthomas/participle/v2 v2.0.0-alpha6 h1:6IeFBBLWi0xcTk4ModH9UKkLBYf5l5OzaYkJOjZW1rg=
+github.com/alecthomas/participle/v2 v2.0.0-alpha6/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/alecthomas/participle/v2/lexer/stateful"
+	"github.com/alecthomas/repr"
+)
+
+// var timeUnits = []string{"s", "m", "h", "sec(s)?", "min(s)", "hr(s)?"}
+// var distanceUnits = []string{"mt(s)?", "km(s)?", "mi", "mile(s)?", "ft(s)?"}
+// var repetitionUnits = []string{"x"}
+
+var workoutLexer = stateful.MustSimple([]stateful.Rule{
+	{Name: `Quantity`, Pattern: `\d+(?:\.\d+)?(?i)[a-z]*`, Action: nil},
+	{Name: `CTitle`, Pattern: `##+[^#\n]*`, Action: nil},  // Circuit Title
+	{Name: `WTitle`, Pattern: `#[^#\n]*`, Action: nil},    // Workout Title
+	{Name: "comment", Pattern: `//[^\n]*`, Action: nil},   //
+	{Name: "whitespace", Pattern: `\s+`, Action: nil},     //
+	{Name: `GString`, Pattern: `\S+[^/\n]+`, Action: nil}, // Greedy String
+})
+
+type Workout struct {
+	Identifier string     `parser:"@WTitle?"`
+	Sets       []*Set     `parser:"( @@"`
+	Circuits   []*Circuit `parser:"| @@ )*"`
+}
+
+type Tag struct {
+	Pos        lexer.Position
+	Identifier string `parser:"@Label"`
+	GString    string `parser:"@GString"`
+}
+
+type Circuit struct {
+	Identifier string `parser:"@CTitle"`
+	Sets       []*Set `parser:"@@*"`
+}
+
+type Set struct {
+	Pos lexer.Position
+
+	Quantity *Quantity `parser:"@Quantity"`
+	Exercise *Exercise `parser:"@@"`
+}
+
+type Quantity struct {
+	Value float64
+	Unit  string
+}
+
+var notNumber = regexp.MustCompile(`\D+`)
+
+func (q *Quantity) Capture(values []string) (err error) {
+	val := values[0]
+	var unit string
+
+	match := notNumber.FindStringIndex(val)
+	if match != nil {
+		unit = val[match[0]:]
+		val = val[0:match[0]] //always re-assign last
+	}
+
+	q.Unit = unit
+	q.Value, err = strconv.ParseFloat(val, 64)
+
+	return err
+}
+
+type Exercise struct {
+	Pos lexer.Position
+
+	GString string `parser:"@GString"`
+}
+
+var parser = participle.MustBuild(&Workout{},
+	participle.Lexer(workoutLexer),
+)
+
+func Parse(wod *Workout, r io.Reader) error {
+	if err := parser.Parse("", r, wod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	wod := &Workout{}
+
+	if err := Parse(wod, os.Stdin); err != nil {
+		fmt.Printf("+%v\n", err)
+	}
+
+	repr.Println(wod, repr.Indent("  "), repr.OmitEmpty(true))
+
+	fmt.Println(parser.String())
+}

--- a/pkg/main_test.go
+++ b/pkg/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/repr"
+)
+
+func TestParse(t *testing.T) {
+	samples := []string{
+		"testdata/minimal.txt",
+		"testdata/circuits.txt",
+		"testdata/wod-annie.txt",
+		"testdata/wod-mary.txt",
+		"testdata/wod-murph.txt",
+		"testdata/v0-parser-full.txt",
+	}
+
+	for _, path := range samples {
+		t.Run(path, func(t *testing.T) {
+			f, err := os.Open(path)
+			if err != nil {
+				t.Error(err)
+			}
+			defer f.Close()
+
+			wod := &Workout{}
+			if err := Parse(wod, f); err != nil {
+				t.Log(repr.String(wod, repr.Indent(" "), repr.OmitEmpty(true)))
+				t.Log(parser.String())
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/testdata/circuits.txt
+++ b/pkg/testdata/circuits.txt
@@ -1,4 +1,4 @@
-// This is not a title
+<!-- This is not a title -->
 
 ## Push set - Superset
 
@@ -7,17 +7,18 @@
 10	Push ups
 1m	Rest
 
-// Un-even amount of empty lines
+<!-- Un-even amount of empty lines -->
 
 
 10	Push ups
 1m	Rest
 
-## Pull set // NOT a comment
+## Pull set // NOT a comment - Superset <!-- Inline comment-->
+
 8	Austrlian pull ups
-// ^ This line is using tabs
+<!-- ^ This line is using tabs -->
 1m  Rest
-// ^ This line is using spaces
+<!-- ^ This line is using spaces -->
 8	Austrlian pull ups
 1M	Rest
 8	Austrlian pull ups

--- a/pkg/testdata/circuits.txt
+++ b/pkg/testdata/circuits.txt
@@ -1,0 +1,23 @@
+// This is not a title
+
+## Push set
+
+10	Push ups
+1m	Rest
+// In between comment
+10	Push ups    // After exercise comment
+1m	Rest
+
+// Un-even amount of empty lines
+
+
+10	Push ups
+1m	Rest
+
+## Pull set // NOT a comment
+8	Austrlian pull ups // This line is using tabs
+1m  Rest // This line is using spaces
+8	Austrlian pull ups
+1M	Rest // Key unsensitve for time units
+8	Austrlian pull ups
+1m	Rest

--- a/pkg/testdata/circuits.txt
+++ b/pkg/testdata/circuits.txt
@@ -1,11 +1,10 @@
 // This is not a title
 
-## Push set
+## Push set - Superset
 
 10	Push ups
 1m	Rest
-// In between comment
-10	Push ups    // After exercise comment
+10	Push ups
 1m	Rest
 
 // Un-even amount of empty lines
@@ -15,9 +14,11 @@
 1m	Rest
 
 ## Pull set // NOT a comment
-8	Austrlian pull ups // This line is using tabs
-1m  Rest // This line is using spaces
 8	Austrlian pull ups
-1M	Rest // Key unsensitve for time units
+// ^ This line is using tabs
+1m  Rest
+// ^ This line is using spaces
+8	Austrlian pull ups
+1M	Rest
 8	Austrlian pull ups
 1m	Rest

--- a/pkg/testdata/minimal.txt
+++ b/pkg/testdata/minimal.txt
@@ -1,9 +1,9 @@
 
 
 10x	Push ups 1/2
-// ^ This line is using tabs
-1m  Rest
-// ^ This line is using spaces
+<!-- ^ This line is using tabs -->
+1m    Rest
+<!-- ^ This line is using spaces -->
 10X	Push ups
 1M	Rest
 10	Push ups
@@ -11,4 +11,4 @@
 
 
 
-// How about a comment over here ?
+<!--  How about a comment over here ? -->

--- a/pkg/testdata/minimal.txt
+++ b/pkg/testdata/minimal.txt
@@ -1,0 +1,12 @@
+
+
+10x	Push ups // This line is using tabs
+1m	Rest // This line is using spaces
+10X	Push ups
+1M	Rest // Key unsensitve for time units
+10	Push ups
+1m	Rest
+
+
+
+// How about a comment over here ?

--- a/pkg/testdata/minimal.txt
+++ b/pkg/testdata/minimal.txt
@@ -1,9 +1,11 @@
 
 
-10x	Push ups // This line is using tabs
-1m	Rest // This line is using spaces
+10x	Push ups 1/2
+// ^ This line is using tabs
+1m  Rest
+// ^ This line is using spaces
 10X	Push ups
-1M	Rest // Key unsensitve for time units
+1M	Rest
 10	Push ups
 1m	Rest
 

--- a/pkg/testdata/v0-parser-full.txt
+++ b/pkg/testdata/v0-parser-full.txt
@@ -4,14 +4,14 @@
 // v0 Workout language goes as follows:
 //
 //      Workout = <wtitle>? (Set | Circuit)* .
+//      Circuit = <ctitle> Set+ .
 //      Set = <quantity> Exercise .
 //      Exercise = <gstring> .
-//      Circuit = <ctitle> Set* .
 //
 // == Details worth noticing
 // - All the strings are "greedy" making this language newline dependent
 // - Comments were defined for mere convenience on the language design
-// - Based on the last point ^^^, the usage of // on titles is allowed
+// - Comments are only when // are used at the beginning of the line
 // - The parser follows a formal language but it *must* be forgiving on user input
 //
 // Got a suggestion? Pull requests are welcome ;)
@@ -20,7 +20,7 @@
 # ////////// The sample workout //////////
 
 10m mobility warm up //
-//                   ^^^ Empty comment ignored as exptect
+//                   ^^ Became part of the exercise text
 
 ## Push set
 10	Push ups
@@ -28,19 +28,22 @@
 10	Push ups
 1m	Rest
 10	Push ups
-1M	Rest // Key unsensitve for time units
+1M	Rest
+//  Any word after a number will be taken as an "unit"
 
-## //> Pull set <//
+## // Pull set //
 
-8	Austrlian pull ups  // <--- This line is using tabs
-1m  Rest                // <--- This line is using spaces
+8	Austrlian pull ups
+// ^^ This line is using tabs
+1m  Rest
+// ^^ This line is using spaces
 8	Austrlian pull ups
 1M	Rest
 8	Austrlian pull ups
 1m	Rest
 
 ## Core set - 4x rest: 1m
-// The metadata in the title is not recognized *yet*
+//          ^ The text after the " - " has been idetified as metadata
 
 10x	Crunches
 1m	Rest

--- a/pkg/testdata/v0-parser-full.txt
+++ b/pkg/testdata/v0-parser-full.txt
@@ -1,49 +1,66 @@
-// Testing all the capabilities supported by v0 Workout language parser.
-//
-// In case I forget to document this somewhere the EBNF representation of the
-// v0 Workout language goes as follows:
-//
-//      Workout = <wtitle>? (Set | Circuit)* .
-//      Circuit = <ctitle> Set+ .
-//      Set = <quantity> Exercise .
-//      Exercise = <gstring> .
-//
-// == Details worth noticing
-// - All the strings are "greedy" making this language newline dependent
-// - Comments were defined for mere convenience on the language design
-// - Comments are only when // are used at the beginning of the line
-// - The parser follows a formal language but it *must* be forgiving on user input
-//
-// Got a suggestion? Pull requests are welcome ;)
-//
+<!--
+Testing all the capabilities supported by v0 Workout language parser.
 
-# ////////// The sample workout //////////
+In case I forget to document this somewhere the EBNF representation of the
+v0 Workout language goes as follows:
 
-10m mobility warm up //
-//                   ^^ Became part of the exercise text
+      Workout = <wodtitle>? (Set | Circuit)* .
+      Circuit = Title+ Set* .
+      Set = <quantity> Exercise .
+      Exercise = <gstring> .
+      Title = Fragment* (<metadiv> Metadata+)? <titleend> .
+      Fragment = (<tgstring> | <puntc>) .
+      Metadata = (<wodtype> | <quantity> | Word) .
+      Word = <ident> (<colon> Tag)? .
+      Tag = (<quantity> | <ident>) .
+
+== Details worth noticing
+- This language's goal is to be flexible enough for humans to share their workouts
+- This language takes inspiration over Markdown due to its popularity, but it is not fully compatible
+- This language simulates 2 column tables using spaces and newlines.
+- ^ Unfortunately this langauge's tables do not render correctly on MD viewers without workarounds
+- Markdonw elements like title and comments work as expected
+- As a rule of thumbs is suggested to add an extra new line for every title.
+- ^ Otherwise, if that title holds metadata will end up consuming the first execise as metadata
+- All the strings outside the titles are "greedy" so the comments do not work there
+
+Got a suggestion? Pull requests are welcome ;)
+-->
+
+# // The sample workout //
+
+10m mobility warm up
 
 ## Push set
+
 10	Push ups
 1m	Rest
+
 10	Push ups
 1m	Rest
+
 10	Push ups
 1M	Rest
-//  Any word after a number will be taken as an "unit"
+
 
 ## // Pull set //
 
 8	Austrlian pull ups
-// ^^ This line is using tabs
-1m  Rest
-// ^^ This line is using spaces
+1m	Rest
 8	Austrlian pull ups
-1M	Rest
+1m    Rest
 8	Austrlian pull ups
 1m	Rest
 
 ## Core set - 4x rest: 1m
-//          ^ The text after the " - " has been idetified as metadata
 
 10x	Crunches
 1m	Rest
+
+## Cardio set - 4x
+
+10x	Jumping jacks
+1m	rest
+
+200mts	run
+1m		rest

--- a/pkg/testdata/v0-parser-full.txt
+++ b/pkg/testdata/v0-parser-full.txt
@@ -1,0 +1,46 @@
+// Testing all the capabilities supported by v0 Workout language parser.
+//
+// In case I forget to document this somewhere the EBNF representation of the
+// v0 Workout language goes as follows:
+//
+//      Workout = <wtitle>? (Set | Circuit)* .
+//      Set = <quantity> Exercise .
+//      Exercise = <gstring> .
+//      Circuit = <ctitle> Set* .
+//
+// == Details worth noticing
+// - All the strings are "greedy" making this language newline dependent
+// - Comments were defined for mere convenience on the language design
+// - Based on the last point ^^^, the usage of // on titles is allowed
+// - The parser follows a formal language but it *must* be forgiving on user input
+//
+// Got a suggestion? Pull requests are welcome ;)
+//
+
+# ////////// The sample workout //////////
+
+10m mobility warm up //
+//                   ^^^ Empty comment ignored as exptect
+
+## Push set
+10	Push ups
+1m	Rest
+10	Push ups
+1m	Rest
+10	Push ups
+1M	Rest // Key unsensitve for time units
+
+## //> Pull set <//
+
+8	Austrlian pull ups  // <--- This line is using tabs
+1m  Rest                // <--- This line is using spaces
+8	Austrlian pull ups
+1M	Rest
+8	Austrlian pull ups
+1m	Rest
+
+## Core set - 4x rest: 1m
+// The metadata in the title is not recognized *yet*
+
+10x	Crunches
+1m	Rest

--- a/pkg/testdata/v0-parser-full.txt
+++ b/pkg/testdata/v0-parser-full.txt
@@ -4,15 +4,14 @@ Testing all the capabilities supported by v0 Workout language parser.
 In case I forget to document this somewhere the EBNF representation of the
 v0 Workout language goes as follows:
 
-      Workout = <wodtitle>? (Set | Circuit)* .
+      Workout = (Set | Circuit)* .
+      Set = <quantity> <gstring> .
       Circuit = Title+ Set* .
-      Set = <quantity> Exercise .
-      Exercise = <gstring> .
-      Title = Fragment* (<metadiv> Metadata+)? <titleend> .
-      Fragment = (<tgstring> | <puntc>) .
-      Metadata = (<wodtype> | <quantity> | Word) .
-      Word = <ident> (<colon> Tag)? .
-      Tag = (<quantity> | <ident>) .
+      Title = <titlestart> TitleFragment* (<metadiv> Metadata+)? <titleend> .
+      TitleFragment = (<tgstring> | <puntc>) .
+      Metadata = (<wodtype> | <quantity> | MetaWord) .
+      MetaWord = <ident> (<colon> MataTag)? .
+      MataTag = (<quantity> | <ident>) .
 
 == Details worth noticing
 - This language's goal is to be flexible enough for humans to share their workouts

--- a/pkg/testdata/wod-annie.txt
+++ b/pkg/testdata/wod-annie.txt
@@ -1,0 +1,12 @@
+## Annie - For Time
+
+50	double-unders
+50	sit-ups
+40	double-unders
+40	sit-ups
+30	double-unders
+30	sit-ups
+20	double-unders
+20	sit-ups
+10	double-unders
+10	sit-ups

--- a/pkg/testdata/wod-mary.txt
+++ b/pkg/testdata/wod-mary.txt
@@ -1,0 +1,5 @@
+## Mary - AMRAP 20m
+
+5	Handstand push-ups
+10	Pistol squats, alterning
+15	Pull-ups

--- a/pkg/testdata/wod-mary.txt
+++ b/pkg/testdata/wod-mary.txt
@@ -2,4 +2,4 @@
 
 5	Handstand push-ups
 10	Pistol squats, alterning
-15	Pull-ups -- min: 3
+15	Pull-ups

--- a/pkg/testdata/wod-mary.txt
+++ b/pkg/testdata/wod-mary.txt
@@ -2,4 +2,4 @@
 
 5	Handstand push-ups
 10	Pistol squats, alterning
-15	Pull-ups
+15	Pull-ups -- min: 3

--- a/pkg/testdata/wod-murph.txt
+++ b/pkg/testdata/wod-murph.txt
@@ -2,6 +2,6 @@
 
 1mile	run
 100		pull-ups
-200		push-ups
+200		push-ups 1/2 // y el comentario?
 300		air squats
 1		mile run

--- a/pkg/testdata/wod-murph.txt
+++ b/pkg/testdata/wod-murph.txt
@@ -2,6 +2,6 @@
 
 1mile	run
 100		pull-ups
-200		push-ups 1/2 // y el comentario?
+200		push-ups
 300		air squats
 1		mile run

--- a/pkg/testdata/wod-murph.txt
+++ b/pkg/testdata/wod-murph.txt
@@ -1,0 +1,7 @@
+## Murph - For Time
+
+1mile	run
+100		pull-ups
+200		push-ups
+300		air squats
+1		mile run


### PR DESCRIPTION
Having "human readable first" in mind, the WoD v0 language has born. It is a markdown superset-ish, and aims mimic how the workouts are expressed on the whiteboards you find on the gym's. For example, here you can find the "mary" workout:

```markdown
## Mary - AMRAP 20m

5	Handstand push-ups
10	Pistol squats, alterning
15	Pull-ups
```

The impotant parts are:

1. The most atomic expression of a workout is a set (a number of repetitions followed by an exercise)
2. Any metadata comes within the "title". The semantics does not matter at this point
3. Several examples can be found on `pkg/testdata`.

The WAC cli is able to parse the WoD language v0, so while it is incubating will be used as a linter managed by GitHub actions.